### PR TITLE
🙈 Add `data/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Do not add contents of the `data/` directory
+data
+
 user_metadata.csv
 *.zip
 


### PR DESCRIPTION
The `data` directory likely contains information that cannot be shared in public yet.

This adds an entry to the `.gitignore` to help avoid committing it.