### PR TITLE
➕ Add `tqdm` dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==2.0.3
 plotly==5.6.0
 pandas>=1.0.0
+tqdm


### PR DESCRIPTION
I don't _think_ the version matters at the moment, but we might pin it in the future.